### PR TITLE
Do not pass command as a string to docker

### DIFF
--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -38,7 +38,7 @@ To compile the document, run the Docker container as follows:
 
 [source,console]
 --
-docker run -v "$(pwd)":/metanorma/ -w /metanorma ribose/metanorma "metanorma -t csd -x xml,html,pdf,doc rfc6350.adoc"
+docker run -v "$(pwd)":/metanorma/ -w /metanorma ribose/metanorma metanorma -t csd -x xml,html,pdf,doc rfc6350.adoc
 --
 
 NOTE: If you use Metanorma-CLI instead of Docker,


### PR DESCRIPTION
The current document suggests using the `""`  around the actual command, which is miss leading and will throw an error, so this commit updates it to the correct format, details: https://github.com/metanorma/metanorma-docker/issues/25