### PR TITLE
Refactor to use base styling from isodoc

### DIFF
--- a/lib/isodoc/csd/html/_coverpage.scss
+++ b/lib/isodoc/csd/html/_coverpage.scss
@@ -16,7 +16,7 @@
 }
 
 .coverpage-maturity {
-  @coverpageStageBlock();
+  @include coverpageStageBlock();
 }
 
 .coverpage-title {

--- a/lib/isodoc/csd/html/_coverpage.scss
+++ b/lib/isodoc/csd/html/_coverpage.scss
@@ -1,0 +1,128 @@
+.coverpage {
+  text-align: center;
+  padding-left: 1.5em;
+}
+
+.wrapper-top {
+  background-color: #0e1a85;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAACXBIWXMAABYlAAAWJQFJUiTwAAADwUlEQVR4nO3YgQ2AMAwDwcAiWZ1NizrH30lIeIEq9nPOGSDqPgC7+93v/suy3Mmvhx+6VAAIcwFAmc4nyzYAIMgGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAIS5AKCs3oFk2QYAJNkAIMwFAGX1DiTLNgAgyQYAYS4AKKt3IFm2AQBJNgAIcwFAWb0DybINAEiyAUCYCwDK6h1Ilm0AQJINAMJcAFBW70CybAMAkmwAEOYCgLJ6B5JlGwCQZAOAMBcAlNU7kCzbAIAkGwCEuQCgrN6BZNkGACTZACDMBQBl9Q4kyzYAIMkGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAIS5AKCs3oFk2QYAJNkAIMwFAGX1DiTLNgAgyQYAYS4AKKt3IFm2AQBJNgAIcwFAWb0DybINAEiyAUCYCwDK6h1Ilm0AQJINAMJcAFBW70CybAMAkmwAEOYCgLJ6B5JlGwCQZAOAMBcAlNU7kCzbAIAkGwCEuQCgrN6BZNkGACTZACDMBQBl9Q4kyzYAIMkGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAFTNzA9ggAr9aahO8QAAAABJRU5ErkJggg==');
+  color: #ffffff;
+  padding: 2em 0;
+}
+
+.doc-number {
+  font-size: 0.5em;
+  font-family: $bodyfont;
+}
+
+.coverpage-maturity {
+  @coverpageStageBlock();
+}
+
+.coverpage-title {
+  padding-bottom: 0.5em;
+  font-family: $headerfont;
+  font-size: 1.2em;
+	line-height: 1.2em;
+	font-weight: 600;
+	padding-left: 1em;
+	padding-right: 1em;
+}
+
+.title-section1 {
+  padding: 0 2em 0 3em;
+}
+
+.prefatory-section {
+  padding: 0 3em 0 6em;
+}
+
+.zzSTDTitle1, .MsoCommentText {
+  display: none;
+}
+
+.coverpage-logo span, .coverpage-tc-name span {
+  font-family: $bodyfont;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.coverpage-tc-name {
+  font-size: 1.2em;
+  line-height: 1.2em;
+  margin: 0.25em 0;
+}
+
+.coverpage-contributors {
+  margin-top: 1em;
+  line-height: 1.5em;
+  font-weight: 300;
+
+  .role {
+    font-variant-caps: all-small-caps;
+    background: #f7f7f7;
+    border-radius: 5px;
+    padding: 0.1em 0.5em;
+    margin-left: 1em;
+    color: #485094;
+    font-size: 0.9em;
+    font-weight: 900;
+  }
+
+  .person {
+    display: block;
+    font-weight: 300;
+  }
+}
+
+
+// Document Identity
+
+.coverpage-doc-identity {
+  font-size: 2em;
+  line-height: 2em;
+}
+
+.coverpage-title .title-second {
+  display: none;
+}
+
+.coverpage-stage-block {
+  font-family: $bodyfont;
+  font-weight: 700;
+  font-size: 1.25em;
+  margin: 2em 0em 2em 0em;
+  text-transform: uppercase;
+}
+
+
+// Draft warning
+
+.coverpage-warning {
+  border-top: solid 1px #f36f36;
+  border-bottom: solid 1px #f36f36;
+  margin: 1em 2em;
+  color: #485094;
+  padding: 1em;
+
+  .title {
+    color: #f36f36;
+    font-family: $headerfont;
+    font-weight: 700;
+    text-transform: uppercase;
+    font-size: 1.2em;
+  }
+}
+
+
+// Copyright
+
+.copyright {
+  padding: 1em;
+  font-size: 0.9em;
+  text-align: left;
+
+  .name, .address {
+    color: #485094;
+  }
+}

--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -53,8 +53,6 @@ nav {
   @include sidebarNavToggle(
     $colorBg: #1d1d1d,
     $colorFg: white);
-
-  z-index: 100;
 }
 
 #toc {

--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -10,6 +10,7 @@ $doctype-colors-list: (
   advisory: #BD9391
 );
 
+
 $docstage-colors-list: (
   proposal: #39A0ED,
   working-draft: #2D7393,
@@ -21,11 +22,8 @@ $docstage-colors-list: (
   cancelled: #2E382E,
 );
 
-@import 'base_style/reset';
-@import 'base_style/typography';
-@import 'base_style/nav';
-@import 'base_style/blocks';
-@import 'base_style/bands';
+
+@import 'base_style/all';
 
 
 body {
@@ -60,7 +58,7 @@ nav {
 }
 
 #toc {
-  @include toc($colorLink: #485094);
+  @include toc($colorLink: #485094, $colorLinkActiveBg: #1d1d1d, $colorLinkActiveFg: white);
 }
 
 .rule {
@@ -79,22 +77,9 @@ nav {
   @include docBand($order: 2, $textLength: 210px, $offset: 180px);
 }
 
-.coverpage-maturity {
-  font-family: $bodyfont;
-  font-weight: 400;
-  font-size: 1em;
-  margin: 0 0 2em 0;
-  text-transform: uppercase;
-}
 
 
-div.figure {
-  @include figureBlock();
-}
-
-
-
-/* Titles */
+/* Typograpy */
 
 h1, h2, h3, h4, h5, h6 {
   color: #0e1a85;
@@ -116,11 +101,20 @@ h1 {
 h2 {
   font-size: 1.3em;
   font-weight: 400;
+
+  p {
+    display: inline;
+  }
 }
 
 h3 {
   font-size: 1.1em;
   font-weight: 400;
+}
+
+p {
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 
@@ -144,15 +138,16 @@ p.Terms {
   margin: 0;
 }
 
+
+/* Links, selection */
+
 @include elementStyles(
   $color: #485094,
   $colorHighlightBg: #1d1d1d,
   $colorHighlightFg: white);
 
 
-/*
-    3.3 Lists
-*/
+/* Lists */
 
 ol {
   margin-left: 1.2em;
@@ -190,25 +185,7 @@ main li {
 }
 
 
-
-/*
-    3.4 Rules
-*/
-
-    .rule {
-        width: 100%;
-        height: 1px;
-        background-color: #0e1a85;
-        margin: 2em 0;
-      }
-
-h2 p {
-  display: inline;
-}
-
-/*
-    3.5 Bibliograhy
-*/
+/* Bibliograhy */
 
 p.Biblio, p.NormRef {
   margin-top: 1em;
@@ -219,109 +196,82 @@ p.Biblio:before, p.NormRef:before {
   padding-right: 1em;
 }
 
-/*
-    3.6 Source Code + figures
-*/
 
-.figure, .Sourcecode {
-    font-family: $monospacefont;
-    font-variant-ligatures: none;
-    background-color: #f7f7f7;
-    font-size: 0.8em;
-    line-height: 1.6em;
-    padding: 1.5em;
-    margin: 2em 0 1em 0;
-    overflow: auto;
+/* Blocks */
+
+.figure {
+  @include figureBlock();
+  @include monospaceBlockStyle();
 }
 
-.FigureTitle, .SourceTitle, .AdmonitionTitle {
-    font-weight: 700;
-    font-size: 1em;
-    text-align: center;
+.Sourcecode {
+  @include sourceBlock(#f7f7f7);
+
+  .example & {
+    background: none;
+  }
 }
 
-/*
-    3.7 Notes
-*/
+.Admonition {
+  @include admonitionBlock();
+}
 
 .Note, .Admonition {
-    color: #47430c;
-    padding: 0.25em;
-    margin: 0;
-}
-
-.Note p, .Admonition p {
-  margin: 1em;
+  color: #47430c;
+  padding: 0.25em;
+  margin: 0;
 }
 
 .Note {
   background-color: #fff495;
+
+  p {
+    margin: 1em;
+  }
 }
 
 .Admonition {
-  background-color: #ffcccc;
 }
 
-/*
-    3.8 Examples
-*/
+
+/* Examples */
 
 table.example {
-    background-color: #e1eef1;
+  background-color: #e1eef1;
 }
 
 td.example {
-    padding: 0 1em 0 1em;
-    margin: 2em 0 1em 0;
+  padding: 0 1em 0 1em;
+  margin: 2em 0 1em 0;
 }
 
 .example {
-    background-color: #e1eef1;
-    padding: 0.5em;
-    margin: 2em 0 1em 0;
-    text-align: left;
-    padding-left: 2em;
+  background-color: #e1eef1;
+  padding: 0.5em;
+  margin: 2em 0 1em 0;
+  text-align: left;
+  padding-left: 2em;
 }
 
 .example p {
-    margin: 0;
+  margin: 0;
 }
 
 .example .example-title {
-    font-weight: 700;
-    text-transform: uppercase;
-    margin-left:-1.5em;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-left:-1.5em;
 }
-
 
 .example .Sourcecode {
-      background: none;
+  background: none;
 }
 
-/*
-    3.9 Tables
-*/
+
+/* Tables */
 
 table {
-  width: 100%;
-  font-weight: 300;
-  margin: 1em 0 2em 0;
-  margin-left: auto;
-  margin-right: auto;
-  padding-right: 2em;
-}
-
-table, th, td {
-  border: 1px solid black;
-  font-size: 0.95em;
-}
-
-td, th {
-  padding: 1em;
-}
-
-td.header {
-  font-weight: 400;
+  @include table($border: 1px solid black);
 }
 
 p.TableTitle {
@@ -330,9 +280,8 @@ p.TableTitle {
   font-weight: 400;
 }
 
-/*
-  3.10 Footnotes
-*/
+
+/* Footnotes */
 
 a.footnote-number {
     vertical-align: super;
@@ -344,38 +293,31 @@ a.footnote-number {
 }
 
 
-/*
-    3.11 Blockquotes
-*/
+/* Blockquotes */
 
 .Quote {
-    background-color: #f7f7f7;
-    font-style: italic;
-    width: 80%;
-    padding: 1.5em;
-    margin-top: 2em;
-    margin-left: auto;
-    margin-right: auto;
+  background-color: #f7f7f7;
+  font-style: italic;
+  width: 80%;
+  padding: 1.5em;
+  margin-top: 2em;
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.QuoteAttribution
-        {text-align:right;}
+.QuoteAttribution {
+  text-align: right;
+}
 
 
-/*
-    3.12 Formulas
-*/
+/* Formulas */
 
 .formula, .Formula {
-    background-color: #f7f7f7;
-    padding: 1.5em;
-    margin-top: 2em;
-    text-align: center;
+  @include formulaBlock(#f7f7f7);
 }
 
-/*
-    3.13 Contact Info
-*/
+
+/* Contact Info */
 
 .contact-info {
   background-color: #f7f7f7;
@@ -385,232 +327,59 @@ a.footnote-number {
   margin-left: auto;
   margin-right: auto;
   text-align: left;
+
+  p, a {
+    font-family: $monospacefont;
+    font-variant-ligatures: none;
+    font-weight: 400;
+    line-height: 1.3em;
+    font-size: 1em;
+    margin: 0;
+  }
+
+  a:hover {
+    color: #485094;
+    background: none;
+    text-decoration: underline;
+    box-shadow: none;
+  }
+
+  .name {
+    font-weight: 700;
+  }
 }
 
-.contact-info p, .contact-info a {
-  font-family: $monospacefont;
-  font-variant-ligatures: none;
-  font-weight: 400;
-  line-height: 1.3em;
-  font-size: 1em;
-  margin: 0;
-}
 
-.contact-info .name {
-  font-weight: 700;
-}
-
-/*
-    Keywords
-*/
+/* Keywords */
 
 span.keyword {
   font-weight: 600;
 }
 
-/*
-    Paragraphs
-*/
 
-p {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
 
 /* Admonitions */
 
 .Admonition, .admonition {
-    background-color: #ffb3b3;
-    /* color: #47430c;*/
-    padding: 0.5em;
-    margin: 1.5em 0 1.5em 0;
-    text-align: left;
-}
+  background-color: #ffb3b3;
+  padding: 0.5em;
+  margin: 1.5em 0 1.5em 0;
+  text-align: left;
 
-.Admonition p, .admonition p {
+  p {
     margin: 0;
-}
-
-
-/*
-    4.0 Page header
-*/
-
-/*
-    4.1 Top Logo
-*/
-
-.wrapper-top {
-    background-color:#0e1a85;
-    /* background-image: url("img/dots@2x.png"); */
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAACXBIWXMAABYlAAAWJQFJUiTwAAADwUlEQVR4nO3YgQ2AMAwDwcAiWZ1NizrH30lIeIEq9nPOGSDqPgC7+93v/suy3Mmvhx+6VAAIcwFAmc4nyzYAIMgGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAIS5AKCs3oFk2QYAJNkAIMwFAGX1DiTLNgAgyQYAYS4AKKt3IFm2AQBJNgAIcwFAWb0DybINAEiyAUCYCwDK6h1Ilm0AQJINAMJcAFBW70CybAMAkmwAEOYCgLJ6B5JlGwCQZAOAMBcAlNU7kCzbAIAkGwCEuQCgrN6BZNkGACTZACDMBQBl9Q4kyzYAIMkGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAIS5AKCs3oFk2QYAJNkAIMwFAGX1DiTLNgAgyQYAYS4AKKt3IFm2AQBJNgAIcwFAWb0DybINAEiyAUCYCwDK6h1Ilm0AQJINAMJcAFBW70CybAMAkmwAEOYCgLJ6B5JlGwCQZAOAMBcAlNU7kCzbAIAkGwCEuQCgrN6BZNkGACTZACDMBQBl9Q4kyzYAIMkGAGEuACirdyBZtgEASTYACHMBQFm9A8myDQBIsgFAmAsAyuodSJZtAECSDQDCXABQVu9AsmwDAJJsABDmAoCyegeSZRsAkGQDgDAXAJTVO5As2wCAJBsAhLkAoKzegWTZBgAk2QAgzAUAZfUOJMs2ACDJBgBhLgAoq3cgWbYBAEk2AAhzAUBZvQPJsg0ASLIBQJgLAMrqHUiWbQBAkg0AwlwAUFbvQLJsAwCSbAAQ5gKAsnoHkmUbAJBkA4AwFwCU1TuQLNsAgCQbAFTNzA9ggAr9aahO8QAAAABJRU5ErkJggg==');
-    color: #ffffff;
-    padding: 2em 0;
-}
-
-.doc-number {
-  font-size: 0.5em;
-  font-family: $bodyfont;
-}
-
-.coverpage-title {
-  padding-bottom: 0.5em;
-  font-family: $headerfont;
-  font-size: 1.2em;
-	line-height: 1.2em;
-	font-weight: 600;
-	padding-left: 1em;
-	padding-right: 1em;
-}
-
-.title-section1 {
-  padding: 0 2em 0 3em;
-}
-
-.prefatory-section {
-  padding: 0 3em 0 6em;
-}
-
-
-.zzSTDTitle1, .MsoCommentText {
-  display: none;
-}
-
-
-.coverpage {
-  text-align: center;
-  padding-left: 1.5em;
-}
-
-.coverpage-logo span, .coverpage-tc-name span {
-  font-family: $bodyfont;
-  text-transform: uppercase;
-  font-weight: 600;
-}
-
-.coverpage-tc-name {
-  font-size: 1.2em;
-  line-height: 1.2em;
-  margin: 0.25em 0;
-}
-
-.coverpage-contributors {
-  margin-top: 1em;
-  line-height: 1.5em;
-  font-weight: 300;
-}
-
-.coverpage-contributors .role {
-  font-variant-caps: all-small-caps;
-  background: #f7f7f7;
-  border-radius: 5px;
-  padding: 0.1em 0.5em;
-  margin-left: 1em;
-  color: #485094;
-  font-size: 0.9em;
-  font-weight: 900;
-}
-
-.coverpage-contributors .person {
-  display: block;
-  font-weight: 300;
-}
-
-/*
-    4.2 Document Identity
-*/
-
-  .coverpage-doc-identity {
-    font-size: 2em;
-    line-height: 2em;
   }
+}
 
 
-  .coverpage-title .title-second {
-    display: none;
-  }
-
-  .coverpage-stage-block {
-    font-family: $bodyfont;
-    font-weight: 700;
-    font-size: 1.25em;
-    margin: 2em 0em 2em 0em;
-    text-transform: uppercase;
-  }
+@import '_coverpage';
 
 
-
-
-/*
-    4.3 Draft Warning
-*/
-
-
-  .coverpage-warning {
-    border-top: solid 1px #f36f36;
-    border-bottom: solid 1px #f36f36;
-    margin: 1em 2em;
-    color: #485094;
-    padding: 1em;
-  }
-
-  .coverpage-warning .title {
-    color: #f36f36;
-    font-family: $headerfont;
-    font-weight: 700;
-    text-transform: uppercase;
-    font-size: 1.2em;
-  }
-
-
-
-/*
-    4.4 Copyright
-*/
-
-  .copyright {
-    padding: 1em;
-    font-size: 0.9em;
-    text-align: left;
-  }
-
-
-  .copyright .name, .copyright .address {color: #485094;}
-
-
-
-/*
-    5.0 Other styles
-*/
-
-
-
-/*
-To top button
-*/
+// To top button
 
 #myBtn {
-    font-family: $monospacefont;
-    font-variant-ligatures: none;
-    display: none;
-    position: fixed;
-    bottom: 20px;
-    right: 30px;
-    z-index: 99;
-    font-size: 12px;
-    border: none;
-    outline: none;
-    background-color: #1d1d1d;
-    opacity: 0.15;
-    color: white;
-    cursor: pointer;
-    padding: 10px 15px 10px 15px;
-    border-radius: 4px;
-  }
-
-  #myBtn:hover {
-    opacity: 1;
-  }
+  @include toTopBtn($color: white, $colorBg: #1d1d1d);
+}
 
 a.anchorjs-link:hover {
   background: none;
@@ -619,39 +388,15 @@ a.anchorjs-link:hover {
 }
 
 @page {
-    margin: 2cm 1cm 2cm 1cm;
+  margin: 2cm 1cm 2cm 1cm;
 }
 
 @media print {
-    h1, .title-section1 {page-break-before: always;}
-    #toggle, .document-stage-band,
-    .document-type-band,#myBtn {display: none;}
-    .container {padding-left: 0;}
-
-
-  nav {
-    position: relative;
-    width: auto;
-    font-size: 0.9em;
-    overflow: auto;
-    padding: 0;
-    margin-right: 0;
-    background-color: white; }
-
-  #toc .toc-active a {
-  color: #485094; }
-
-  #toc .toc-active, #toc li:hover {
-  background: white;
-  box-shadow: none !important; }
-
-  #toc li:hover a {
-  color: black; }
-
+  h1, .title-section1 {
+    page-break-before: always;
+  }
 
   h1.toc-contents {
-    margin-top: 2em; }
-
-
+    margin-top: 2em;
+  }
 }
-

--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -1,339 +1,4 @@
-/*
-    0 CSS RESET
-*/
-
-/* http://meyerweb.com/eric/tools/css/reset/
-   v2.0 | 20110126
-   License: none (public domain)
-*/
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-        margin: 0;
-        padding: 0;
-}
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-        border: 0;
-        font-size: 100%;
-}
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, tt, var,
-b, u, i, center,
-dl, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-        vertical-align: baseline;
-}
-
-
-html, body, div, span, applet, object, iframe,
-p, blockquote,
-a, abbr, acronym, address, big, cite,
-del, dfn, em, img, ins, q, s,
-small, strike, strong, sub, sup, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-  font-family: $bodyfont;
-}
-
-code, pre, tt, kbd, samp {
-  font-family: $monospacefont;
-  font-variant-ligatures: none;
-}
-
-code *, pre *, tt *, kbd *, samp * {
-  font-family: $monospacefont !important;
-  font-variant-ligatures: none;
-}
-
-h1, h2, h3, h4, h5, h6, .h2Annex {
-  font-family: $headerfont;
-}
-
-dl {
-  display: grid;
-  grid-template-columns: max-content auto;
-}
-
-dt {
-  grid-column-start: 1;
-}
-
-dd {
-  grid-column-start: 2;
-}
-
-dd p, dt p {
-  margin-top: 0px;
-}
-
-
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
-
-
-/*
-    1. HTML & Body
-*/
-
-  body {
-    margin: 0;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 100%;
-    color: #1d1d1d;
-    font-weight: 300;
-    font-size: 15px;
-    line-height: 1.4em;
-    background-color: #ffffff;
-  }
-
-  main {margin: 0 3em 0 6em;}
-
-  #toc{
-    font-family: $bodyfont;
-    font-weight: 400;
-  }
-
-/*
-    2. Responsive navigation layout
-*/
-
-
-@media screen and (min-width: 768px) {
-    nav {
-        position: fixed;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 323px;
-        font-size: 0.9em;
-        overflow: auto;
-        padding: 0 0 0 45px;
-        margin-right: 30px;
-        background-color:#f7f7f7;
-    }
-
-    #toggle {
-        position: fixed;
-        height: 100%;
-        width: 30px;
-        background-color:#1d1d1d;
-        color: white!important;
-        cursor: pointer;
-        z-index: 100;
-    }
-
-    #toggle span {
-        text-align: center;
-        width: 100%;
-        position: absolute;
-        top: 50%;
-        transform: translate(0, -50%);
-
-    }
-
-
-    .container {
-        padding-left: 360px;
-    }
-
-    .rule.toc {
-        display: none;
-    }
-
-    h1.toc-contents {
-        margin-top: 1em;
-    }
-
-    ul#toc-list {
-        padding:0;
-        margin:0;
-    }
-}
-
-@media screen and (max-width: 768px) {
-    #toc {
-        padding: 0 1.5em 0 1.5em;
-        overflow: visible;
-    }
-}
-
-  div.figure > img {
-    margin-left: auto;
-margin-right: auto;
-display: block;
-max-width: 100%;
-height: auto;
-  }
-
-
-#toc ul {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
-#toc li a {
-    padding: 5px 10px;
-}
-
-#toc a {
-    color: #485094;
-    text-decoration: none;
-    display: block;
-}
-
-#toc a:hover {
-    box-shadow: none;
-    color: white;
-}
-
-#toc .h2 {
-    padding-left: 30px;
-}
-
-#toc .h3 {
-    padding-left: 50px;
-}
-
-#toc .toc-active a {
-    color: white;
-}
-
-#toc .toc-active, #toc li:hover {
-    background: #1d1d1d;
-    box-shadow: inset -5px 0px 10px -5px #1d1d1d!important;
-
-}
-
-#toc li:hover a {
-    color: white;
-}
-
-/*
-    Document types + stages
-*/
-
-.document-type-band {
-    left:0;
-    top:180px;
-    height: 100%;
-    position: fixed;
-    display: block;
-    z-index: 99;
-    /*box-shadow: -5px 0px 10px #1d1d1d*/
-
-}
-
-.document-stage-band {
-    left:0;
-    top:0;
-    height: 100%;
-    position: fixed;
-    display: block;
-    z-index: 98;
-    box-shadow: -5px 0px 10px #1d1d1d
-}
-
-.document-type {
-    position: relative;
-    width: 25px;
-}
-
-.document-stage {
-    position: relative;
-    width: 25px;
-}
-
-p.document-type, p.document-stage {
-  color: white;
-  text-transform: uppercase;
-  font-size: 0.9em;
-  font-weight: 400;
-  letter-spacing: 0.05em;
-  margin:0;
-  margin-left: 6px;
-  writing-mode:tb-rl;
-  transform:rotate(180deg);
-	white-space:nowrap;
-	display:block;
-  bottom:0;
-}
-
-p.document-type {
-    font-weight: 400;
-    height: 210px;
-}
-
-#governance-band p.document-type {
-    font-weight: 400;
-    height: 230px!important;
-}
-
-p.document-stage {
-    font-weight: 300;
-    height:160px;
-}
-
-
-$doctype-colors-list:(
+$doctype-colors-list: (
   standard: #0AC442,
   directive: #540D6E,
   guide: #D183C9,
@@ -345,16 +10,7 @@ $doctype-colors-list:(
   advisory: #BD9391
 );
 
-@each $key,$val in $doctype-colors-list{
-  ##{$key}-band {
-    background-color: #{$val};
-  }
-  ##{$key} {
-    border-bottom: solid 3px #{$val};
-  }
-}
-
-$docstage-colors-list:(
+$docstage-colors-list: (
   proposal: #39A0ED,
   working-draft: #2D7393,
   committee-draft: #2A6B7C,
@@ -365,13 +21,62 @@ $docstage-colors-list:(
   cancelled: #2E382E,
 );
 
-@each $key,$val in $docstage-colors-list{
-  ##{$key}-band {
-    background-color: #{$val};
+@import 'base_style/reset';
+@import 'base_style/typography';
+@import 'base_style/nav';
+@import 'base_style/blocks';
+@import 'base_style/bands';
+
+
+body {
+  // line-height: 1;
+
+  @include bodyStyle1(
+    $fontSize: 15px, $fontWeight: 300, $lineHeight: 1.4em,
+    $colorText: #1d1d1d, $colorBackground: #fff);
+}
+
+.container {
+  @include sidebarNavContainer(360px);
+}
+
+nav {
+  @include sidebarNav(
+    $offsetLeft: 45px,
+    $colorBg: #f7f7f7,
+    $width: 323px);
+
+  #toc {
+    @include sidebarToc();
   }
-  ##{$key} {
-    border-bottom: solid 3px #{$val};
+}
+
+#toggle {
+  @include sidebarNavToggle(
+    $colorBg: #1d1d1d,
+    $colorFg: white);
+
+  z-index: 100;
+}
+
+#toc {
+  @include toc($colorLink: #485094);
+}
+
+.rule {
+  @include rule(1px, #0e1a85, 2em 0);
+
+  &.toc {
+    @include tocSeparator();
   }
+}
+
+.document-stage-band {
+  @include docBand($order: 1, $textLength: 160px, $fontWeight: 300);
+}
+
+.document-type-band {
+  @include docBand($order: 2, $textLength: 210px, $offset: 180px);
 }
 
 .coverpage-maturity {
@@ -383,123 +88,71 @@ $docstage-colors-list:(
 }
 
 
-/*
-    3. TYPOGRAPHY
-*/
-
-/*
-    3.1 Titles
-*/
-
-  h1,h2,h3,h4,h5,h6 {
-    font-family: $headerfont;
-    color: #0e1a85;
-    font-weight: 600;
-    margin-top: 2em;
-    margin-bottom: 0.3em;
-  }
-
-  h1 {
-    font-size: 1.4em;
-    text-transform: uppercase;
-    margin-top: 2em;
-  }
-
-  h1#content {
-      margin-top: 2em;
-  }
-
-  h2 {
-    font-size: 1.3em;
-    font-weight: 400;
-  }
-
-  h3 {
-    font-size: 1.1em;
-    font-weight: 400;
-  }
-
-  /*
-  span[id^="toc"]:after {
-    float: left;
-    padding-right: 4px;
-    margin-left: -20px;
-    font-family: "Font Awesome 5 Free";
-    font-weight: 900;
-    font-size: 0.8em;
-    color: #cfcfcf;
-    content: "\f0c1";
-  }
-  */
-
-  .TermNum, .Terms, .AltTerms {
-    color: #485094;
-    font-weight: 400;
-  }
-
-  p.TermNum {
-    font-size: 0.9em;
-    line-height: 1em;
-    margin: 0;
-    margin-top: 2em;
-  }
-
-  p.Terms {
-    font-size: 1.1em;
-    line-height: 1.7em;
-    margin: 0;
-  }
-
-  /*
-  p.AltTerms {
-    font-style: italic;
-    margin: 0;
-  }
-  */
-
-span.obligation {
-    font-weight: 400;
+div.figure {
+  @include figureBlock();
 }
 
 
-/*
-    3.2 Links
-*/
 
-    a, a:visited{
-        text-decoration: none;
-        color: #485094;
-    }
+/* Titles */
 
-    a:hover {
-        color: white;
-        background: #1d1d1d;
-        box-shadow: 3px 0 0 #1d1d1d, -3px 0 0 #1d1d1d;
-        /* padding: 2px 0 2px 0; */
-    }
+h1, h2, h3, h4, h5, h6 {
+  color: #0e1a85;
+  font-weight: 600;
+  margin-top: 2em;
+  margin-bottom: 0.3em;
+}
 
-    ::selection {
-        background: #1d1d1d; /* WebKit/Blink Browsers */
-        color: white;
-      }
-      ::-moz-selection {
-        background: #1d1d1d; /* Gecko Browsers */
-        color: white;
-      }
+h1 {
+  font-size: 1.4em;
+  text-transform: uppercase;
+  margin-top: 2em;
 
-      .contact-info a:hover {
-          color: #485094;
-          text-decoration: underline;
-          background: none;
-          box-shadow: 0 0 0 0;
-      }
+  &#content {
+    margin-top: 2em;
+  }
+}
 
+h2 {
+  font-size: 1.3em;
+  font-weight: 400;
+}
+
+h3 {
+  font-size: 1.1em;
+  font-weight: 400;
+}
+
+
+/* Terms */
+
+.TermNum, .Terms, .AltTerms {
+  color: #485094;
+  font-weight: 400;
+}
+
+p.TermNum {
+  font-size: 0.9em;
+  line-height: 1em;
+  margin: 0;
+  margin-top: 2em;
+}
+
+p.Terms {
+  font-size: 1.1em;
+  line-height: 1.7em;
+  margin: 0;
+}
+
+@include elementStyles(
+  $color: #485094,
+  $colorHighlightBg: #1d1d1d,
+  $colorHighlightFg: white);
 
 
 /*
     3.3 Lists
 */
-
 
 ol {
   margin-left: 1.2em;
@@ -637,7 +290,6 @@ td.example {
 .example .example-title {
     font-weight: 700;
     text-transform: uppercase;
-    margin-top:0;
     margin-left:-1.5em;
 }
 
@@ -651,7 +303,6 @@ td.example {
 */
 
 table {
-  border-collapse: collapse;
   width: 100%;
   font-weight: 300;
   margin: 1em 0 2em 0;


### PR DESCRIPTION
Post-refactor htmlstyle.scss is down to 402 LoC, from 657 originally. Still a lot, but much of the styling is unfortunately not shared across flavors.

**Note:** This code requires https://github.com/metanorma/isodoc/pull/126 to be merged first. If this code goes to release without the isodoc PR, it’ll break document build.

See more in https://github.com/metanorma/isodoc/issues/112#issuecomment-536482378.