### PR TITLE
HTML docstage/doctype layout conflict fix

### DIFF
--- a/lib/isodoc/csd/html/htmlstyle.scss
+++ b/lib/isodoc/csd/html/htmlstyle.scss
@@ -85,9 +85,12 @@ nav {
 }
 
 .document-type-band {
-  @include docBand($order: 2, $textLength: 210px, $offset: 180px);
-}
+  @include docBand($order: 2, $offset: 180px);
 
+  .document-type {
+    top: 20px;
+  }
+}
 
 
 /* Typograpy */


### PR DESCRIPTION
metanorma/metanorma-ogc#128:

HTML docstage/doctype layout conflict fix,
Use new format docBand isodoc mixin